### PR TITLE
Fix mobile hero section gap

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import CTA from '@/components/CTA'
 
 export default function Home() {
   return (
-    <div className="pt-16 lg:pt-20">
+    <div className="pt-0 lg:pt-20">
       <Hero />
       <Mission />
       <Features />

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -22,7 +22,7 @@ const Footer = () => {
               <h3 className="text-xl font-cheddar font-bold gradient-text">PKBA</h3>
             </div>
             <p className="text-gray-300 font-montserrat text-sm">
-              Club de parkour associatif au Bassin d'Arcachon. 
+              Club de parkour associatif du Bassin d'Arcachon. 
               Encadrement professionnel, progression et sécurité.
             </p>
             <p className="text-gray-400 font-montserrat text-xs">

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -7,7 +7,7 @@ import { ArrowRight, Calendar, ShoppingBag } from 'lucide-react'
 
 const Hero = () => {
   return (
-    <section className="relative h-[calc(100vh-4rem)] lg:h-[calc(100vh-5rem)] flex items-center justify-center bg-gradient-to-br from-primary via-secondary to-primary overflow-hidden">
+    <section className="relative h-[100vh] lg:h-[calc(100vh-5rem)] flex items-center justify-center bg-gradient-to-br from-primary via-secondary to-primary overflow-hidden">
       {/* Background Image */}
       <div className="absolute inset-0 z-0">
         <Image


### PR DESCRIPTION
Remove mobile top padding from home page wrapper and adjust hero height to eliminate the gap between the navbar and hero on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-41d8b3a1-d199-4bd6-94ee-52a92c1db2e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-41d8b3a1-d199-4bd6-94ee-52a92c1db2e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

